### PR TITLE
fix: UI for Safari

### DIFF
--- a/polyfill/cos-polyfill.js
+++ b/polyfill/cos-polyfill.js
@@ -51,6 +51,7 @@
     font-family: system-ui, sans-serif;
     font-size: 14px;
     border: none;
+    block-size: 100%;
     width: fit-content;
     max-width: 500px;
   }
@@ -65,8 +66,14 @@
   }
   section {
     display: flex;
-    align-items: anchor-center;
+    align-items: center;
     gap: 10px;
+  }
+
+  @supports (align-items: anchor-center) {
+    section {
+      align-items: anchor-center;
+    }
   }
   @media (prefers-color-scheme: dark) {
     dialog {


### PR DESCRIPTION
Minimal changes to offer the same experience in Safari without affecting chrome.

UI in Safari before:
<img width="529" alt="Screenshot 2025-02-03 at 5 23 05 PM" src="https://github.com/user-attachments/assets/ecc897c0-ddfb-454c-a1fd-8a041d00e0d3" />
UI in Safari After:
<img width="548" alt="Screenshot 2025-02-03 at 5 25 18 PM" src="https://github.com/user-attachments/assets/e9b9111f-07ca-450b-aeef-038bfe301e5f" />
