### PR TITLE
docs: clarify that hash value must be a lowercase hex string of length 64

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,7 +501,7 @@ try {
 
 The current hashing algorithm is [SHA-256](https://w3c.github.io/webcrypto/#alg-sha-256), implemented by the **Web Crypto API**. If hashing best practices should change, COS will reflect the [implementers' recommendation](https://w3c.github.io/webcrypto/#algorithm-recommendations-implementers) in the Web Crypto API.
 
-The hashing algorithm used is encoded in each hash object's `algorithm` field of the `hashes` array as a [`HashAlgorithmIdentifier`](https://w3c.github.io/webcrypto/#dom-hashalgorithmidentifier). This flexible design allows changing the hashing algorithm in the future. The hash string must be a valid lowercase hexadecimal string of length 64 (for SHA-256).
+The hashing algorithm used is encoded in each hash object's `algorithm` field of the `hashes` array as a [`HashAlgorithmIdentifier`](https://w3c.github.io/webcrypto/#dom-hashalgorithmidentifier). This flexible design allows changing the hashing algorithm in the future. The hash string must be a valid lowercase hexadecimal string of length 64 (for SHA-256). The `algorithm` field must be a valid [`HashAlgorithmIdentifier`](https://w3c.github.io/webcrypto/#dom-hashalgorithmidentifier), e.g. `"SHA-256"`.
 
 ```js
 const hashes = [
@@ -669,7 +669,7 @@ interface CrossOriginStorageManager {
 
 dictionary CrossOriginStorageRequestFileHandleHash {
   DOMString value; // Must be a valid lowercase hexadecimal string of length 64 (for SHA-256).
-  DOMString algorithm;
+  DOMString algorithm; // Must be a valid HashAlgorithmIdentifier (https://w3c.github.io/webcrypto/#dom-hashalgorithmidentifier), e.g. "SHA-256".
 }
 
 dictionary CrossOriginStorageRequestFileHandleOptions {

--- a/README.md
+++ b/README.md
@@ -501,7 +501,7 @@ try {
 
 The current hashing algorithm is [SHA-256](https://w3c.github.io/webcrypto/#alg-sha-256), implemented by the **Web Crypto API**. If hashing best practices should change, COS will reflect the [implementers' recommendation](https://w3c.github.io/webcrypto/#algorithm-recommendations-implementers) in the Web Crypto API.
 
-The hashing algorithm used is encoded in each hash object's `algorithm` field of the `hashes` array as a [`HashAlgorithmIdentifier`](https://w3c.github.io/webcrypto/#dom-hashalgorithmidentifier). This flexible design allows changing the hashing algorithm in the future.
+The hashing algorithm used is encoded in each hash object's `algorithm` field of the `hashes` array as a [`HashAlgorithmIdentifier`](https://w3c.github.io/webcrypto/#dom-hashalgorithmidentifier). This flexible design allows changing the hashing algorithm in the future. The hash string must be a valid lowercase hexadecimal string of length 64 (for SHA-256).
 
 ```js
 const hashes = [
@@ -668,7 +668,7 @@ interface CrossOriginStorageManager {
 };
 
 dictionary CrossOriginStorageRequestFileHandleHash {
-  DOMString value;
+  DOMString value; // Must be a valid lowercase hexadecimal string of length 64 (for SHA-256).
   DOMString algorithm;
 }
 


### PR DESCRIPTION
The hash string must be a valid lowercase hexadecimal string of length 64.

Added this clarification in two places where it makes sense:
1. The **Hashing** section under _Detailed design discussion_, where the `value` field format is described.
2. **Appendix A: Full IDL**, as an inline comment on the `DOMString value` field of `CrossOriginStorageRequestFileHandleHash`.