### PR TITLE
docs: specify TypeError for invalid hash.value or hash.algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ The **COS** API will be available through the `navigator.crossOriginStorage` int
 1. Request a sequence of `FileSystemFileHandle` objects for the files, specifying the files' hashes.
 1. Write the files' data to the `FileSystemFileHandle` objects and store them in Cross-Origin Storage. When `writableStream.write(data)` is called, the user agent must verify that the hash of `data` matches the hash declared in the corresponding entry of the `hashes` array, using the algorithm specified in `hash.algorithm`. If the hashes do not match, the user agent must throw a `NotAllowedError` `DOMException` and must not store the data in COS.
 
+> [!NOTE]
+> If `hash.value` is not a valid lowercase hexadecimal string of length 64, or `hash.algorithm` is not a valid [`HashAlgorithmIdentifier`](https://w3c.github.io/webcrypto/#dom-hashalgorithmidentifier), the user agent must throw a `TypeError`.
+
 ##### Example: Storing a single file
 
 ```js


### PR DESCRIPTION
The Explainer currently only mentions `NotAllowedError` and `NotFoundError`, but says nothing about what happens when the hash arguments themselves are malformed.

Following Web platform convention (and what the polyfill already does, see web-ai-community/cross-origin-storage-extension#1), this adds a normative note specifying that the user agent must throw a `TypeError` if:

- `hash.value` is not a valid lowercase hexadecimal string of length 64, or
- `hash.algorithm` is not a valid [`HashAlgorithmIdentifier`](https://w3c.github.io/webcrypto/#dom-hashalgorithmidentifier)

The note is placed at the end of the **Storing files** steps, just before the first code example, where the hash format constraints are most immediately relevant.